### PR TITLE
column name

### DIFF
--- a/backend/src/main/java/com/brestlife/backend/entity/CategoryEntity.java
+++ b/backend/src/main/java/com/brestlife/backend/entity/CategoryEntity.java
@@ -13,7 +13,7 @@ public class CategoryEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, unique = true, length = 100, name = "sub_category")
     private String subCategory;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
This pull request includes a change to the `CategoryEntity` class in the `backend` module, specifically modifying the `subCategory` column to include a name attribute.

* [`backend/src/main/java/com/brestlife/backend/entity/CategoryEntity.java`](diffhunk://#diff-1c1749504b3882e4ab39c9eafaa09221a76c5e40ee0893ed70829ebd67f4bb89L16-R16): Added the `name = "sub_category"` attribute to the `subCategory` column definition.