### PR TITLE
Add summary field to Place entity and update DiscoveryPage to display it

### DIFF
--- a/backend/src/main/java/com/brestlife/backend/entity/PlaceEntity.java
+++ b/backend/src/main/java/com/brestlife/backend/entity/PlaceEntity.java
@@ -17,6 +17,9 @@ public class PlaceEntity {
     @Column(nullable = false, length = 150)
     private String name;
 
+    @Column(nullable = true, length = 200)
+    private String summary;
+
     @Column(columnDefinition = "TEXT")
     private String description;
 

--- a/frontend/src/gen/openapi/types.gen.ts
+++ b/frontend/src/gen/openapi/types.gen.ts
@@ -21,6 +21,7 @@ export type Category = {
 export type Place = {
     id?: number;
     name?: string;
+    summary?: string;
     description?: string;
     category?: Category;
     address?: string;

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -8,6 +8,7 @@ export function DiscoveryPage() {
   const [places, setPlaces] = useState<Place[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedPlace, setSelectedPlace] = useState<Place | null>(null);
   const [filters, setFilters] = useState({ price: '' });
 
   // Récupération des lieux
@@ -104,12 +105,15 @@ export function DiscoveryPage() {
                     {place.price && place.price > 0 ? `${place.price}€` : 'Gratuit'}
                   </span>
                 </div>
-                <p className="text-gray-600 mb-4">{place.description}</p>
+                <p className="text-gray-600 mb-4">{place.summary}</p>
                 <div className="flex items-center text-gray-500 mb-4">
                   <MapPin className="w-4 h-4 mr-2" />
                   <span className="text-sm">{place.address || 'Lieu inconnu'}</span>
                 </div>
-                <button className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition-colors">
+                <button
+                    className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition-colors"
+                    onClick={() => setSelectedPlace(place)}
+                >
                   En savoir plus
                 </button>
               </div>
@@ -119,6 +123,41 @@ export function DiscoveryPage() {
           <p className="text-center text-gray-500 col-span-full">Aucun lieu trouvé.</p>
         )}
       </div>
+      {selectedPlace && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-lg">
+              <h2 className="text-2xl font-bold mb-4">{selectedPlace.name}</h2>
+              <img
+                  src={selectedPlace.imageUrl || 'https://via.placeholder.com/300'}
+                  alt={selectedPlace.name}
+                  className="w-full h-48 object-cover mb-4"
+              />
+              <div className="flex justify-between items-start mb-2">
+                <h2 className="text-xl font-semibold">{selectedPlace.name}</h2>
+                <span
+                    className={`px-2 py-1 rounded text-sm ${
+                        selectedPlace.price && selectedPlace.price > 0 ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'
+                    }`}
+                >
+                                        {selectedPlace.price && selectedPlace.price > 0 ? `${selectedPlace.price}€` : 'Gratuit'}
+                                    </span>
+              </div>
+              <p className="text-gray-600 mb-4">{selectedPlace.description}</p>
+              <div className="flex items-center text-gray-500 mb-4">
+                <MapPin className="w-4 h-4 mr-2" />
+                <span className="text-sm">{selectedPlace.address || 'évènement inconnu'}</span>
+              </div>
+              <div className="flex justify-end">
+                <button
+                    className="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors"
+                    onClick={() => setSelectedPlace(null)}
+                >
+                  Fermer
+                </button>
+              </div>
+            </div>
+          </div>
+      )}
     </div>
   );
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -543,6 +543,8 @@ components:
           format: int32
         name:
           type: string
+        summary:
+          type: string
         description:
           type: string
         category:


### PR DESCRIPTION
This pull request introduces a new `summary` field to the `Place` entity and updates the frontend to display this new field. Additionally, it enhances the `DiscoveryPage` component to include a modal for more detailed information about a selected place.

### Backend changes:
* [`backend/src/main/java/com/brestlife/backend/entity/PlaceEntity.java`](diffhunk://#diff-f42ba89de1c85967d08fca3a82077fcd0d8f47ff27d7a9c564066898cc98115cR20-R22): Added a new `summary` field to the `PlaceEntity` class.

### Frontend changes:
* [`frontend/src/gen/openapi/types.gen.ts`](diffhunk://#diff-c1208af8adcc418656b2e518fede4dd21b9ba829e9a523e274a0b07cb0fa216aR24): Added the `summary` field to the `Place` type.
* `frontend/src/pages/DiscoveryPage.tsx`: 
  * Added `selectedPlace` state to manage the currently selected place.
  * Updated the component to display the `summary` instead of the `description` in the place list.
  * Added a modal to display detailed information about the selected place, including its description, address, and price.

### API changes:
* [`openapi.yaml`](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39R546-R547): Added the `summary` field to the `Place` schema in the OpenAPI specification.