### PR TITLE
feat: add Docker Buildx setup to deployment configuration

### DIFF
--- a/.github/workflows/prod.deploy.yml
+++ b/.github/workflows/prod.deploy.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Packages
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/prod.deploy.yml` file. The change sets up Docker Buildx in the deployment workflow.

* [`.github/workflows/prod.deploy.yml`](diffhunk://#diff-3f9730449af645050880e9bc3aebf80bb2cc9c0e13d07206709529ab062eb19eR25-R27): Added a step to set up Docker Buildx using `docker/setup-buildx-action@v3`.